### PR TITLE
feat(calibration): Implement basic calibration UI and data capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project is primarily an exploration and accessibility tool.
     -   ✅ **Step 1: Display Camera Feed:** The application successfully displays a live feed from the selected webcam.
     -   ✅ **Step 2: Detect Faces:** The application now detects faces and draws bounding boxes around them (correctly mirrored).
     -   ✅ **Step 3: Detect Facial Landmarks (Pupils & Pose):** The application detects pupils and head pose, populating `GazeInputData`, and displays pupil indicators.
+-   **Phase 2: Calibration & Mapping**
+    -   ✅ **Step 4: Basic Calibration UI & Data Capture:** Implemented UI for calibration target display and controls to capture `ScreenGazePair` data.
     -   ... (See `cline_docs/progress.md` for full plan)
 
 ## Core Technologies

--- a/cline_docs/activeContext.md
+++ b/cline_docs/activeContext.md
@@ -2,10 +2,18 @@
 
 ## Current Focus
 
-Implementing **Step 4: Basic Calibration UI & Data Capture** of Phase 2 (Calibration & Mapping).
+Implementing **Step 5: Implement Coordinate Mapping Function** of Phase 2 (Calibration & Mapping).
 
 ## Recent Changes
 
+-   **Completed Step 4: Basic Calibration UI & Data Capture:**
+    -   Defined `ScreenGazePair` struct in `GazeDataTypes.swift`.
+    -   Created `CalibrationViewModel.swift` to manage calibration state (`isCalibrating`, `calibrationPoints`, `collectedData`, `currentCalibrationTargetIndex`) and logic (`startCalibration`, `recordDataPoint`, `finishCalibration`, `cancelCalibration`).
+    -   Created `CalibrationTargetView.swift` to display a visual target.
+    -   Integrated `CalibrationViewModel` into `ContentView.swift`.
+    -   Added UI controls (Start/Record/Cancel buttons) to `ContentView.swift`.
+    -   Conditionally displayed `CalibrationTargetView` based on `calibrationViewModel.isCalibrating` and `currentTargetPoint`.
+    -   Implemented logic to capture `cameraManager.latestGazeData` and store `ScreenGazePair` on button press.
 -   **Completed Step 3: Detect Facial Landmarks (Pupils & Pose):**
     -   Created `GazeDataTypes.swift` with the `GazeInputData` struct.
     -   Modified `CameraManager` to use `VNDetectFaceLandmarksRequest`.
@@ -19,18 +27,13 @@ Implementing **Step 4: Basic Calibration UI & Data Capture** of Phase 2 (Calibra
 
 ## Next Steps
 
-1.  **Implement Step 4: Basic Calibration UI & Data Capture:**
-    *   **Goal:** Implement a simple UI overlay for calibration (displaying target points). Capture the corresponding `GazeInputData` when the user signals they are looking at the target.
+1.  **Implement Step 5: Implement Coordinate Mapping Function:**
+    *   **Goal:** Create a Swift function `estimateScreenCoords(gazeData: GazeInputData, calibrationData: [ScreenGazePair]) -> CGPoint?` that uses calibration data to estimate screen coordinates from live `GazeInputData`.
     *   **Tasks:**
-        *   Define a data structure to hold calibration pairs: `struct ScreenGazePair { let screenPoint: CGPoint; let gazeData: GazeInputData }`. (Likely in `GazeDataTypes.swift`).
-        *   Add state variables to `ContentView` or a new `CalibrationViewModel` to manage calibration state (e.g., `isCalibrating: Bool`, `calibrationPoints: [CGPoint]`, `collectedData: [ScreenGazePair]`, `currentCalibrationTargetIndex: Int`).
-        *   Create a `CalibrationTargetView` (or similar) in SwiftUI that displays a visual target (e.g., a circle) at a specific screen coordinate.
-        *   Modify `ContentView` to overlay `CalibrationTargetView` when `isCalibrating` is true, positioning it based on `calibrationPoints[currentCalibrationTargetIndex]`.
-        *   Add a mechanism (e.g., a button, key press) for the user to signal they are looking at the current target.
-        *   When the signal is received:
-            *   Capture the current `cameraManager.latestGazeData`.
-            *   Capture the screen coordinates of the current target.
-            *   Store the `ScreenGazePair`.
-            *   Advance `currentCalibrationTargetIndex`.
-            *   Handle completion of the calibration sequence.
-        *   Add UI elements (e.g., buttons) to start and potentially cancel calibration.
+        *   Decide on an initial mapping algorithm (e.g., simple interpolation, weighted average based on proximity, polynomial regression - start simple).
+        *   Create a new file (e.g., `CoordinateMapper.swift`) or add the function to an existing relevant file (perhaps `CalibrationViewModel` or a dedicated utility struct/class).
+        *   Implement the `estimateScreenCoords` function, taking live `GazeInputData` and the `collectedData` (`[ScreenGazePair]`) as input.
+        *   The function should return an estimated `CGPoint` representing screen coordinates, or `nil` if estimation isn't possible (e.g., insufficient calibration data).
+        *   Add basic logging or debugging output within the function to see the estimated coordinates.
+        *   (Optional) Add unit tests for the mapping function if feasible with sample data.
+        *   Integrate the call to this function into `ContentView` or `CameraManager` to continuously estimate gaze coordinates when not calibrating (initially just print the output).

--- a/cline_docs/progress.md
+++ b/cline_docs/progress.md
@@ -36,7 +36,7 @@ Step 1 (Display Camera Feed) is complete.
     *   **Goal:** Implement a simple UI overlay for calibration (displaying target points). Capture the corresponding `GazeInputData` when the user signals they are looking at the target.
     *   **Technologies:** SwiftUI, `Vision` data handling.
     *   **Deliverable:** A calibration mode where the user looks at specific points, and the application records pairs of (Target Screen Coordinate, `GazeInputData`). Data can initially be stored in memory or printed.
-    *   **Status:** Pending
+    *   **Status:** **Completed - 4/25/2025**
 
 5.  **Step 5: Implement Coordinate Mapping Function**
     *   **Goal:** Create a Swift function `estimateScreenCoords(gazeData: GazeInputData, calibrationData: [ScreenGazePair]) -> CGPoint?` that uses calibration data to estimate screen coordinates from live `GazeInputData`.
@@ -60,4 +60,4 @@ Step 1 (Display Camera Feed) is complete.
 
 ## Next Immediate Step
 
--   Begin implementation of **Step 4: Basic Calibration UI & Data Capture**.
+-   Begin implementation of **Step 5: Implement Coordinate Mapping Function**.

--- a/deer-mouse/CalibrationTargetView.swift
+++ b/deer-mouse/CalibrationTargetView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// A simple view that displays a visual target (e.g., a circle) at a specific point.
+struct CalibrationTargetView: View {
+    let position: CGPoint
+    let size: CGFloat = 30 // Diameter of the target
+
+    var body: some View {
+        Circle()
+            .fill(Color.red.opacity(0.7)) // Semi-transparent red circle
+            .frame(width: size, height: size)
+            .position(position) // Position the center of the circle
+            .overlay(
+                Circle() // Add a border for better visibility
+                    .stroke(Color.white, lineWidth: 2)
+                    .frame(width: size, height: size)
+                    .position(position)
+            )
+            .overlay( // Add a smaller center dot
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: size / 5, height: size / 5)
+                    .position(position)
+            )
+    }
+}
+
+#Preview {
+    // Example usage within a ZStack for positioning context
+    ZStack {
+        CalibrationTargetView(position: CGPoint(x: 100, y: 150))
+        CalibrationTargetView(position: CGPoint(x: 300, y: 250))
+    }
+    .frame(width: 400, height: 400)
+    .background(Color.gray)
+}

--- a/deer-mouse/CalibrationViewModel.swift
+++ b/deer-mouse/CalibrationViewModel.swift
@@ -1,0 +1,79 @@
+import Foundation
+import SwiftUI // For CGPoint and ObservableObject
+
+/// Manages the state and logic for the eye gaze calibration process.
+class CalibrationViewModel: ObservableObject {
+
+    /// Indicates whether the calibration process is currently active.
+    @Published var isCalibrating: Bool = false
+
+    /// The sequence of points on the screen the user needs to look at.
+    /// TODO: Define actual points based on screen size. Using placeholders for now.
+    @Published var calibrationPoints: [CGPoint] = [
+        CGPoint(x: 100, y: 100), // Top-left area
+        CGPoint(x: 500, y: 100), // Top-right area
+        CGPoint(x: 500, y: 500), // Bottom-right area
+        CGPoint(x: 100, y: 500), // Bottom-left area
+        CGPoint(x: 300, y: 300)  // Center area
+    ]
+
+    /// Stores the collected data pairs during calibration.
+    @Published var collectedData: [ScreenGazePair] = []
+
+    /// The index of the current calibration target point in the `calibrationPoints` array.
+    @Published var currentCalibrationTargetIndex: Int = 0
+
+    /// Returns the point for the current calibration target. Returns nil if calibration isn't active or is complete.
+    var currentTargetPoint: CGPoint? {
+        guard isCalibrating, currentCalibrationTargetIndex < calibrationPoints.count else {
+            return nil
+        }
+        return calibrationPoints[currentCalibrationTargetIndex]
+    }
+
+    /// Starts the calibration process.
+    func startCalibration() {
+        collectedData = [] // Clear previous data
+        currentCalibrationTargetIndex = 0
+        isCalibrating = true
+        print("Calibration started. Target 1: \(currentTargetPoint ?? CGPoint.zero)")
+    }
+
+    /// Records the gaze data for the current target point and advances to the next target.
+    /// - Parameter gazeData: The `GazeInputData` captured when the user signaled focus.
+    func recordDataPoint(gazeData: GazeInputData) {
+        guard let targetPoint = currentTargetPoint else {
+            print("Error: Tried to record data point but no current target exists.")
+            return
+        }
+
+        let pair = ScreenGazePair(screenPoint: targetPoint, gazeData: gazeData)
+        collectedData.append(pair)
+        print("Collected data for point \(currentCalibrationTargetIndex + 1): \(pair)")
+
+        // Advance to the next point
+        currentCalibrationTargetIndex += 1
+
+        if currentCalibrationTargetIndex >= calibrationPoints.count {
+            // Calibration finished
+            finishCalibration()
+        } else {
+            print("Moving to target \(currentCalibrationTargetIndex + 1): \(currentTargetPoint ?? CGPoint.zero)")
+        }
+    }
+
+    /// Ends the calibration process.
+    func finishCalibration() {
+        isCalibrating = false
+        print("Calibration finished. Collected \(collectedData.count) data points.")
+        // TODO: Trigger the mapping model calculation here or elsewhere.
+    }
+
+    /// Cancels the calibration process.
+    func cancelCalibration() {
+        isCalibrating = false
+        collectedData = []
+        currentCalibrationTargetIndex = 0
+        print("Calibration cancelled.")
+    }
+}

--- a/deer-mouse/GazeDataTypes.swift
+++ b/deer-mouse/GazeDataTypes.swift
@@ -21,3 +21,10 @@ struct GazeInputData {
     // Consider adding interpupillary distance (IPD) later as a proxy for Z-distance.
     // let ipd: CGFloat?
 }
+
+/// Represents a pair of screen coordinates (where a calibration target was shown)
+/// and the corresponding gaze data captured when the user looked at that target.
+struct ScreenGazePair {
+    let screenPoint: CGPoint
+    let gazeData: GazeInputData
+}


### PR DESCRIPTION
Adds the necessary components and logic for Step 4 of the calibration phase.

- Defines the `ScreenGazePair` struct in `GazeDataTypes.swift` to hold calibration data points.
- Creates `CalibrationViewModel.swift` to manage the calibration state (active status, target points, collected data, current index) and provides methods to start, record, cancel, and finish the process.
- Creates `CalibrationTargetView.swift` to display a visual target on the screen.
- Integrates the `CalibrationViewModel` into `ContentView.swift`.
- Adds UI controls (Start, Record Point, Cancel buttons) to `ContentView`.
- Conditionally displays the `CalibrationTargetView` based on the calibration state.
- Implements the action for the "Record Point" button to capture the current `GazeInputData` and the target screen coordinates, storing them as a `ScreenGazePair` in the view model.
- Updates README and Memory Bank documentation.

This establishes the foundation for collecting the data needed for the coordinate mapping function in the next step.
